### PR TITLE
Update CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # FIXME: Unfortunately, C is (at least temporarily) required due to a bug
 # in LLVM 14.  See https://github.com/llvm/llvm-project/issues/53950.


### PR DESCRIPTION
to fix the following error:
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.